### PR TITLE
Add `amount` in `ChargeUpdateParams`

### DIFF
--- a/types/2020-03-02/Charges.d.ts
+++ b/types/2020-03-02/Charges.d.ts
@@ -1366,6 +1366,13 @@ declare module 'stripe' {
        */
       fraud_details?: ChargeUpdateParams.FraudDetails;
 
+      
+      /**
+       * Used for testing Stripe Issuing. Increasing the amount of an authorization. https://stripe.com/docs/issuing/testing#increasing-the-amount-of-an-authorization
+       */
+      amount?: number;
+      
+      
       /**
        * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */


### PR DESCRIPTION
Issue: https://github.com/stripe/stripe-node/issues/869

Unfortunately, this exceptional call:

const charge = await stripe.charges.update(
  'ch_1CmMk3IyNTgGDVfzqgWGCQr5',
  {
    amount: 2500,
  }
);
Described here: https://stripe.com/docs/issuing/testing#increasing-the-amount-of-an-authorization is not correctly typed.

The type error thrown is: Argument of type '{ amount: number; }' is not assignable to parameter of type 'ChargeUpdateParams'.

It is because this hook: Update a charge (https://stripe.com/docs/api/charges/update) doesn't have the value "amount" in the type 'ChargeUpdateParams'.
Thanks!